### PR TITLE
chore(gradle): change distributionUrl to tencent mirrors for resolve …

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https://mirrors.cloud.tencent.com/gradle/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
…connection error while downloading gradle

工具链（gradle）:将distributionUrl更改为腾讯镜像以解决下载gradle时的连接错误